### PR TITLE
Fix build by disabling remote image optimization

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,14 +19,9 @@ export default defineConfig({
     defaultStrategy: "viewport",
   },
 
-  image: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "**.unsplash.com",
-      },
-    ],
-  },
+  // Disable remote image optimization during build to avoid network
+  // requests when processing Markdown files. Remote images will be
+  // used as-is without size inference.
 
   markdown: {
     remarkPlugins: [remarkModifiedTime],

--- a/src/components/OptimizedPicture.astro
+++ b/src/components/OptimizedPicture.astro
@@ -1,11 +1,11 @@
 ---
-import { Picture } from "astro:assets";
+// Use a plain <img> tag to avoid remote image optimization, which
+// requires network access during the build. This prevents build
+// failures when remote images cannot be fetched.
 
 interface Props {
   src: string;
   alt: string;
-  widths?: number[];
-  sizes?: string;
   class?: string;
   loading?: "lazy" | "eager";
   fetchpriority?: "high" | "low" | "auto";
@@ -14,28 +14,16 @@ interface Props {
 const {
   src,
   alt,
-  widths = [320, 640, 960, 1280, 1600, 1960],
-  sizes = `(max-width: 320px) 320px,
-           (max-width: 640px) 640px,
-           (max-width: 960px) 960px,
-           (max-width: 1280px) 1280px,
-           (max-width: 1600px) 1600px,
-           1960px`,
   class: className = "mx-auto w-full max-w-full rounded-lg",
   loading = "lazy",
   fetchpriority = "auto",
 } = Astro.props;
 ---
 
-<Picture
+<img
   src={src}
   alt={alt}
-  widths={widths}
-  sizes={sizes}
-  formats={["avif"]}
-  fallbackFormat="avif"
   class={className}
   loading={loading}
   fetchpriority={fetchpriority}
-  inferSize
 />


### PR DESCRIPTION
## Summary
- disable remote image optimization in `astro.config.mjs`
- replace `<Picture>` with a plain `<img>` to avoid build-time network requests

## Testing
- `pnpm astro check`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_685417895c5c83338b4a15de5669beee